### PR TITLE
Adding availability to use string value in taxRate 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": "^7.1.3",
     "guzzlehttp/guzzle": "6.3.*",
-    "laravel/framework": "5.7",
+    "laravel/framework": "^5.7",
     "nathanmac/parser": "4.*",
     "orchestra/testbench": "3.7"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": "^7.1.3",
     "guzzlehttp/guzzle": "6.3.*",
-    "laravel/framework": "^5.7",
+    "laravel/framework": "5.8.*",
     "nathanmac/parser": "4.*",
     "orchestra/testbench": "3.7"
   },

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -780,7 +780,7 @@ class Client
                         $writer->writeElement('afakulcs', $item['taxRate']);
 
                         $netUnitPrice = $item['netUnitPrice'];
-                        $taxRate = $item['taxRate'];
+                        $taxRate = is_numeric($item['taxRate']) ? $item['taxRate'] : 0;
                         $quantity = $item['quantity'];
                         $netPrice = isset($item['netPrice'])
                             ? $item['netPrice']
@@ -1182,7 +1182,7 @@ class Client
                         'quantity' => (double)$item['mennyiseg'],
                         'quantityUnit' => $item['mennyisegiegyseg'],
                         'netUnitPrice' => (double)$item['nettoegysegar'],
-                        'taxRate' => (double)$item['afakulcs'],
+                        'taxRate' => is_numeric($item['afakulcs']) ? (double)$item['afakulcs'] : $item['afakulcs'],
                         'totalNetPrice' => (double)$item['netto'],
                         'taxValue' => (double)$item['afa'],
                         'totalGrossPrice' => (double)$item['brutto'],
@@ -1266,7 +1266,7 @@ class Client
                     $writer->writeElement('afakulcs', $item['taxRate']);
 
                     $netUnitPrice = $item['netUnitPrice'];
-                    $taxRate = $item['taxRate'];
+                    $taxRate = is_numeric($item['taxRate']) ? $item['taxRate'] : 0;
                     $quantity = $item['quantity'];
                     $netPrice = isset($item['netPrice']) ? $item['netPrice'] : ($netUnitPrice * $quantity);
                     $grossPrice = isset($item['grossPrice']) ? $item['grossPrice'] : $netPrice * (1 + ($taxRate / 100));
@@ -1495,7 +1495,7 @@ class Client
                             'quantityUnit' => $item['mennyisegiEgyseg'],
                             'netUnitPrice' => (double)$item['nettoEgysegar'],
                             'totalNetPrice' => (double)$item['netto'],
-                            'taxRate' => (double)$item['afakulcs'],
+                            'taxRate' => is_numeric($item['afakulcs']) ? (double)$item['afakulcs'] : $item['afakulcs'],
                             'taxValue' => (double)$item['afa'],
                             'totalGrossPrice' => (double)$item['brutto']
                         ];

--- a/src/Internal/Support/InvoiceValidationRules.php
+++ b/src/Internal/Support/InvoiceValidationRules.php
@@ -117,7 +117,7 @@ trait InvoiceValidationRules {
             'items.*.quantity' => ['required', 'integer', 'min:1'],
             'items.*.quantityUnit' => ['required', 'string'],
             'items.*.netUnitPrice' => ['required', 'numeric'],
-            'items.*.taxRate' => ['required', 'numeric'],
+            'items.*.taxRate' => ['required'],
             'items.*.id' => ['sometimes'],
             'items.*.taxValue' => ['numeric'],
             'items.*.totalGrossPrice' => ['numeric'],

--- a/src/Internal/Support/ReceiptValidationRules.php
+++ b/src/Internal/Support/ReceiptValidationRules.php
@@ -64,7 +64,7 @@ trait ReceiptValidationRules {
             'items.*.quantity' => ['required', 'integer', 'min:1'],
             'items.*.quantityUnit' => ['required', 'string'],
             'items.*.netUnitPrice' => ['required', 'numeric'],
-            'items.*.taxRate' => ['required', 'numeric'],
+            'items.*.taxRate' => ['required'],
             'items.*.id' => ['sometimes'],
             'items.*.taxValue' => ['numeric'],
             'items.*.totalGrossPrice' => ['numeric'],


### PR DESCRIPTION
You can send string constans to szamlazz.hu api as described here: https://docs.szamlazz.hu/#vat-rates
Later it would be nice to describe these constant values and check whether there is a typo in the given values.