### PR TITLE
fixed laravel 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package supports the following methods:
 Package can automatically save generated PDF files and store on the given disk. For further information about the configuration possibilities please refer to the [configuration](doc/technical/config.md) documentation.
 
 ## Requirements
-Supports Laravel: **5.5** / **6.*** / **7.***
+Supports Laravel: **5.5** / **6.*** / **7.*** / **8.***
 
 ## Documentations
 For usage please refer to the [technical documentation](doc/technical/documentation.md).

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^7.1.3",
     "ext-simplexml": "*",
     "ext-xmlwriter": "*",
-    "guzzlehttp/guzzle": "6.*",
+    "guzzlehttp/guzzle": "6.* | 7.*",
     "laravel/framework": ">5.6 | 6.* | 7.* | 8.*"
   },
   "require-dev": {


### PR DESCRIPTION
Hey there!

Fixed Laravel 8 support.

Newer versions ships with newer guzzlehttp ( 7 ) , so I added in composer.json.
Beside of that I also extend the readme file, that this version now supports Laravel 8.

Thanks for your work!